### PR TITLE
Fix Crash when Fluid Prospecting with No Fluid Veins

### DIFF
--- a/src/main/java/hellfall/visualores/mixins/gregtech/WidgetProspectingMapMixin.java
+++ b/src/main/java/hellfall/visualores/mixins/gregtech/WidgetProspectingMapMixin.java
@@ -48,7 +48,7 @@ public abstract class WidgetProspectingMapMixin extends Widget {
         ), locals = LocalCapture.CAPTURE_FAILSOFT, remap = false
     )
     private void visualores$injectReadFluidPacket(int id, PacketBuffer buffer, CallbackInfo ci, PacketProspecting packet) {
-        if (packet.mode == ProspectorMode.FLUID) {
+        if (packet.mode == ProspectorMode.FLUID && packet.map[0][0] != null) {
             int fieldX = BedrockFluidVeinHandler.getVeinCoord(packet.chunkX);
             int fieldZ = BedrockFluidVeinHandler.getVeinCoord(packet.chunkZ);
             GTClientCache.instance.addFluid(gui.entityPlayer.getEntityWorld().provider.getDimension(), fieldX, fieldZ,


### PR DESCRIPTION
This PR fixes a crash caused by VisualOres when one tries to fluid prospect in a dimension that does not contain fluid veins.

First reported here:
https://github.com/Nomi-CEu/Nomi-CEu/issues/1411