### PR TITLE
Fix Windows client-only cache path when server IP contains a port

### DIFF
--- a/src/main/java/hellfall/visualores/proxy/VOClientProxy.java
+++ b/src/main/java/hellfall/visualores/proxy/VOClientProxy.java
@@ -133,6 +133,9 @@ public class VOClientProxy extends VOCommonProxy {
             String cacheName = "unknown";
             if (Minecraft.getMinecraft().getCurrentServerData() != null) {
                 cacheName = Minecraft.getMinecraft().getCurrentServerData().serverIP;
+                if (System.getProperty("os.name", "").toLowerCase().contains("win")) {
+                    cacheName = cacheName.replace(':', '~');
+                }
             }
             ClientCacheManager.init("Server-" + cacheName + "-client-only");
         }


### PR DESCRIPTION
This PR fixes a Windows-only crash caused by client-only cache folder names being built from the multiplayer server address.

When connecting to a server using an IP and non-standard port, serverIP contains a `:` character, for example `10.10.10.10:25603`. That character is invalid in Windows file paths, so VisualOres could fail when creating or using the client cache directory.

Change made:

sanitize the server address on Windows only
replace `:` with `~` before building the client-only cache folder name
keep the original server address unchanged on Linux and macOS
This avoids breaking cache paths on Windows while preserving existing behavior on other platforms.

Closes #22 