### PR TITLE
Fix ore veins rendering in Xaero's Minimap

### DIFF
--- a/src/main/java/hellfall/visualores/mixins/xaerominimap/MinimapRendererMixin.java
+++ b/src/main/java/hellfall/visualores/mixins/xaerominimap/MinimapRendererMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import xaero.common.IXaeroMinimap;
+import xaero.common.HudMod;
 import xaero.common.minimap.render.MinimapRenderer;
 import xaero.common.minimap.render.MinimapRendererHelper;
 import xaero.hud.minimap.Minimap;
@@ -33,7 +33,7 @@ public abstract class MinimapRendererMixin {
     @Unique private float angle;
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void visualores$injectConstruct(IXaeroMinimap modMain, Minecraft mc, WaypointMapRenderer waypointMapRenderer, Minimap minimap, CompassRenderer compassRenderer, CallbackInfo ci) {
+    private void visualores$injectConstruct(HudMod modMain, Minecraft mc, WaypointMapRenderer waypointMapRenderer, Minimap minimap, CompassRenderer compassRenderer, CallbackInfo ci) {
         renderer = new GenericMapRenderer();
     }
 


### PR DESCRIPTION
v0.2.8 didn't fix this.
Before:
<img width="295" height="308" alt="image" src="https://github.com/user-attachments/assets/343dd5f5-064f-42f6-b4dc-059b4a4767e1" />
After:
<img width="294" height="308" alt="image" src="https://github.com/user-attachments/assets/242e9bbe-54dd-4932-bff4-8d0c387a2cdf" />
